### PR TITLE
Fix the markup for some R code

### DIFF
--- a/Statistical notes.page
+++ b/Statistical notes.page
@@ -362,7 +362,7 @@ New violations:
 - `[Weight.visceral.fat|Weight.Omron]`
 - `[Weight.muscle|Weight.BMI]`
 
-~~{.R}
+~~~{.R}
 pdap4 <- hc(weightC, blacklist=data.frame(from=c("Weight.body.age", "Weight.resting.metabolism", "Weight.BMI", "Weight.Omron", "Weight.Omron", "Weight.BMI"), to=c("Weight.visceral.fat","Weight.muscle", "Weight.visceral.fat", "Weight.muscle", "Weight.visceral.fat", "Weight.muscle")))
 ~~~
 


### PR DESCRIPTION
Noticed when browsing [Statistical notes](http://www.gwern.net/Statistical%20notes).

![image](https://cloud.githubusercontent.com/assets/964245/16743335/b23bc9a2-47a3-11e6-921c-957b135647e7.png)
