### PR TITLE
Update paragraphizer to use ChatCompletion API with gpt-3.5-turbo.

### DIFF
--- a/build/paragraphizer.py
+++ b/build/paragraphizer.py
@@ -76,20 +76,24 @@
 import sys
 import openai
 
-prompt = """Add double-newlines `\n\n` to split this abstract into paragraphs (one topic per paragraph). From:
-
-\""""
-
 if len(sys.argv) == 1:
     target = sys.stdin.read().strip()
 else:
     target = sys.argv[1]
 
-postPrompt="\"\n\nTo:\n\n\""
+messages = [
+    {"role": "system", "content": "You are a helpful assistant that adds double-newlines to split abstracts into paragraphs."},
+    {"role": "user", "content": f"Add double-newlines to this abstract: {target}"}
+]
 
-result = openai.Completion.create(engine="text-davinci-003",
-                                prompt=prompt+target+postPrompt,
-                                temperature=0, max_tokens=1024, stop="\"")['choices'][0]['text']
+result = openai.ChatCompletion.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+    max_tokens=1024,
+    temperature=0,
+    stop=["User:", "Assistant:"]
+)['choices'][0]['message']['content']
+
 print(result)
 # if target == (result.replace('\n', '')).replace(' ', ''):
 #     print(result)

--- a/build/paragraphizer.py
+++ b/build/paragraphizer.py
@@ -82,8 +82,8 @@ else:
     target = sys.argv[1]
 
 messages = [
-    {"role": "system", "content": "You are a helpful assistant that adds double-newlines to split abstracts into paragraphs."},
-    {"role": "user", "content": f"Add double-newlines to this abstract: {target}"}
+    {"role": "system", "content": "You are a helpful assistant that adds double-newlines to split abstracts into paragraphs (one topic per paragraph.)"},
+    {"role": "user", "content": f"Please process the following abstract (between the '<abstract>' and '</abstract>' tags), by adding double-newlines to split it into paragraphs (one topic per paragraph.) Please include ONLY the resulting text in your output, and NO other conversation or comments.\n\n<abstract>\n{target}\n</abstract>"}
 ]
 
 result = openai.ChatCompletion.create(
@@ -91,7 +91,6 @@ result = openai.ChatCompletion.create(
     messages=messages,
     max_tokens=1024,
     temperature=0,
-    stop=["User:", "Assistant:"]
 )['choices'][0]['message']['content']
 
 print(result)


### PR DESCRIPTION
The first commit was written by GPT-4 at my request. The second commit is me editing the prompts a bit (and removing the stop tokens, which are, redundant in the ChatCompletion context.)

I have done very rough testing. Using this code with GPT-4 (change the model name to "gpt-4") gives nice paragraphs (n=1 test), although they can be a bit short. GPT-3.5 gives even shorter paragraphs (often just one sentence.) I'm not sure it's actually wrong, but it might need some guidance in the prompt about how big a paragraph should be.