### PR TITLE
[Fix] Fixing appearance of noscript warning

### DIFF
--- a/template/default.html
+++ b/template/default.html
@@ -76,17 +76,29 @@
   <!-- CSS for JS-disabled users: ensure that NoScripters know what they are missing even if they jump to a section & miss the warning at top/bottom. -->
   <noscript>
     <style>
-      #markdownBody #noscript-warning-header {
-    	  position: fixed; /* sticky */
-    	  top: 6px; /* at top */
-    	  width: 58%;
-    	  z-index: 99; /* Make sure it is on top */
-    	  background-color: #f8f8f8; /* Set a solid background color so legible while positioned over text */
-    	  border-color: var(--GW-abstract-border-color); /* Make look like theme-toggle/admonitions a bit more */
-    	  border-width: 6px 6px 6px 6px;
-    	  border-style: double;
+      #noscript-warning-header {
+        position: fixed; /* floating */
+        top: 0; /* at the top */
+        left: 0; /* from the left side of the screen, and not the body margin */
+        width: calc(100% - 12px); /* full-width, calculate the exact value, in case one insists on the border */
+        margin: 0 auto; /* don't waste space */
+        z-index: 99; /* Make sure it is on top */
+        /* Note: currently the mode is always dark in noscript mode */
+        background-color: var(--GW-admonition-warning-background-color); /* Background color according to theme */
+        color: var(--GW-admonition-warning-text-color); /* Font color according to theme */
+        border-color: var(--GW-abstract-border-color); /* Make look like theme-toggle/admonitions a bit more */
+        border-width: 6px 6px 6px 6px;
+        border-style: double;
       }
-      #markdownBody #noscript-warning-header p { margin: 10px; }
+      /* markdown is not parsed, adjusting link appearance */
+      #noscript-warning-header a { 
+        color: var(--GW-admonition-warning-text-color);
+        text-shadow: unset; /* unset shadow in noscript mode, as it does not display properly */
+      }
+      #noscript-warning-header p { 
+        margin: 10px;
+        text-indent: unset; /* don't waste space */
+      }
       nav#sidebar { padding-top: 160px; } /* avoid overlap with page header */
     </style>
   </noscript>


### PR DESCRIPTION
Text color is changed from grey-on-white-background to the colors of the admonition CSS style. Fixed broken appearance of links. The floating block size and location are adjusted to avoid wasting space. Another revision is needed if the warning is to be made dismissable without the use of JS.

## Before
![1 before mobile noscript gwern](https://github.com/user-attachments/assets/62361931-50dd-4d35-9548-7892f4282889)
![2 before mobile noscript gwern](https://github.com/user-attachments/assets/75b2d048-cc54-4b21-bbb4-59ddcc41f6f7)
![1 before desktop noscript gwern](https://github.com/user-attachments/assets/19c1e956-36a3-4606-936a-e0b55d50da81)
![2 before desktop noscript gwern](https://github.com/user-attachments/assets/1d852d60-7484-4f58-8c88-6fe5f8d327b4)
## After
![1 after mobile noscript gwern](https://github.com/user-attachments/assets/eb5058b8-f801-4aea-99ff-1729117d7f7b)
![2 after mobile noscript gwern](https://github.com/user-attachments/assets/4be11c14-855a-46f6-902e-28a6aaf0517f)
![1 after desktop noscript gwern](https://github.com/user-attachments/assets/b397b222-02d6-42f8-ad92-62bc50201397)
![2 after desktop noscript gwern](https://github.com/user-attachments/assets/8924556e-cc69-4d02-abad-f75b7fe77726)


