### PR TITLE
fix gwtar.js for safari

### DIFF
--- a/build/gwtar.js
+++ b/build/gwtar.js
@@ -701,4 +701,9 @@ function markAssetWaiting(assetInfo) {
 /***************************************************/
 /*	Begin loading (after the prefix document loads).
  */
-requestIdleCallback(getMainPageHTML);
+
+if ('requestIdleCallback' in window) {
+    requestIdleCallback(getMainPageHTML);
+} else {
+    setTimeout(getMainPageHTML, 1);
+}


### PR DESCRIPTION
currently, gwtar doesn't work at all in Safari (both mobile and web), because it doesn't support requestIdleCallback.

Google has some polyfill here - https://developer.chrome.com/blog/using-requestidlecallback - but that's just too complex. This works too. This fixes gwtar for safari.

https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#browser_compatibility
https://bugs.webkit.org/show_bug.cgi?id=285049
