### PR TITLE
fix(ref): add two-author fallback to /ref/ citation lookup

### DIFF
--- a/js/rewrite.js
+++ b/js/rewrite.js
@@ -274,6 +274,39 @@ addContentLoadHandler("loadReferencedIdentifier", (eventInfo) => {
 							|| normalizedRef.startsWith(entry[0]))
 						&& entry[0] != normalizedRef
 					);
+
+					/*	Two-author fallback: when the user queries for
+						`FOO-YYYY` but the actual ID is `FOO-BAR-YYYY` (a
+						second author), prefix matching misses it because
+						the stored ID is neither a prefix nor a suffix of
+						the query. Splice the stored suffix (surname +
+						year) against the query's year so the reader does
+						not have to guess the second surname. The year
+						tail allows the optional single-letter suffix
+						`generateID`/`dateSuffix` appends for same-year
+						disambiguation (e.g. `2020a`). Surnames use `\S`
+						to cover diacritics and hyphenated names already
+						present in `generateID` output. See #19.
+					 */
+					let twoAuthorPatternParts = normalizedRef.match(/^(\S+?)-([12][0-9][0-9][0-9][a-z]?)$/);
+					if (twoAuthorPatternParts != null) {
+						let firstAuthor = twoAuthorPatternParts[1];
+						let year = twoAuthorPatternParts[2];
+						let escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+						/*	Trailing `[a-z]?` lets a suffix-less query like
+							`foo-2020` still match a disambiguated stored ID
+							such as `foo-bar-2020a`; a query that already
+							carries a suffix just matches the exact year.
+						 */
+						let twoAuthorRegex = new RegExp(`^${escapeRegExp(firstAuthor)}-\\S+?-${escapeRegExp(year)}[a-z]?$`);
+						Object.entries(event.target.response).forEach(entry => {
+							if (twoAuthorRegex.test(entry[0])
+								&& entry[0] != normalizedRef
+								&& idPrefixMatches.every(existing => existing[0] != entry[0]))
+								idPrefixMatches.push(entry);
+						});
+					}
+
 					if (idPrefixMatches.length > 1) {
 						/*	If multiple matches, list them all, transcluding
 							annotations where available (attempt in all cases, and

--- a/js/script-GENERATED.js
+++ b/js/script-GENERATED.js
@@ -15038,6 +15038,39 @@ addContentLoadHandler("loadReferencedIdentifier", (eventInfo) => {
 							|| normalizedRef.startsWith(entry[0]))
 						&& entry[0] != normalizedRef
 					);
+
+					/*	Two-author fallback: when the user queries for
+						`FOO-YYYY` but the actual ID is `FOO-BAR-YYYY` (a
+						second author), prefix matching misses it because
+						the stored ID is neither a prefix nor a suffix of
+						the query. Splice the stored suffix (surname +
+						year) against the query's year so the reader does
+						not have to guess the second surname. The year
+						tail allows the optional single-letter suffix
+						`generateID`/`dateSuffix` appends for same-year
+						disambiguation (e.g. `2020a`). Surnames use `\S`
+						to cover diacritics and hyphenated names already
+						present in `generateID` output. See #19.
+					 */
+					let twoAuthorPatternParts = normalizedRef.match(/^(\S+?)-([12][0-9][0-9][0-9][a-z]?)$/);
+					if (twoAuthorPatternParts != null) {
+						let firstAuthor = twoAuthorPatternParts[1];
+						let year = twoAuthorPatternParts[2];
+						let escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+						/*	Trailing `[a-z]?` lets a suffix-less query like
+							`foo-2020` still match a disambiguated stored ID
+							such as `foo-bar-2020a`; a query that already
+							carries a suffix just matches the exact year.
+						 */
+						let twoAuthorRegex = new RegExp(`^${escapeRegExp(firstAuthor)}-\\S+?-${escapeRegExp(year)}[a-z]?$`);
+						Object.entries(event.target.response).forEach(entry => {
+							if (twoAuthorRegex.test(entry[0])
+								&& entry[0] != normalizedRef
+								&& idPrefixMatches.every(existing => existing[0] != entry[0]))
+								idPrefixMatches.push(entry);
+						});
+					}
+
 					if (idPrefixMatches.length > 1) {
 						/*	If multiple matches, list them all, transcluding
 							annotations where available (attempt in all cases, and


### PR DESCRIPTION
## Summary

When the user typed `/ref/FOO-YYYY` the old fallback only checked `FOO-et-al-YYYY` and prefix matches in both directions, so a citation stored as `FOO-BAR-YYYY` (two-author with a surname the reader does not recall) never surfaced as a suggestion. `rabinovitch-1992` silently went to "Invalid Query" even though `rabinovitch-minegishi-1992` existed.

## Fix

Inside `displayRelevantContentAfterMatchNotFound`, when the query matches `FOO-YYYY` (or `FOO-YYYYa` etc.), sweep the already-loaded mapping for IDs of the form `FOO-<anything>-YYYY` and append any hits to `idPrefixMatches`. Details:

- `\S+?` on both surname positions so diacritics and hyphenated surnames that `generateID` emits keep matching.
- Trailing `[a-z]?` on the year so a suffix-less query like `rabinovitch-1992` also matches same-year-disambiguated stored IDs like `foo-bar-2020a`.
- `escapeRegExp` so surnames with regex metacharacters do not break the pattern.

Mirrored the change in `js/script-GENERATED.js`, which is the bundle actually served -- without that, the behavior change wouldn't reach production.

## Test plan

- `/ref/rabinovitch-1992` now lists `rabinovitch-minegishi-1992` under "Perhaps you want one of these".
- `/ref/rabinovitch-minegishi-1992` continues to resolve directly.
- Queries that already hit on the existing prefix matcher (`/ref/foo-1992` matches `foo-1992-v2`) still appear once and are not duplicated by the new pass.

Fixes #19
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
